### PR TITLE
記事の削除機能実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -35,6 +35,12 @@ class ArticlesController < ApplicationController
         end
     end
 
+    def destroy
+        article = Article.find(params[:id])
+        article.destroy!
+        redirect_to root_path, status: :see_other, notice: '削除に成功しました'
+    end
+
     private
     def article_params
         params.require(:article).permit(:title, :content)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,8 @@
 // Entry point for the build script in your package.json
-import "@hotwired/turbo-rails"
-import "./controllers"
+import '@hotwired/turbo-rails';
+import './controllers';
+
+// RailsのUJS（Unobtrusive JavaScript）を有効化
+// これにより link_to の data-method="delete" などが機能する
+import Rails from '@rails/ujs';
+Rails.start();

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -11,6 +11,7 @@
                 <%= image_tag 'actions.svg', class: 'dropbtn' %>
                 <div class="dropdown-content mini">
                     <%= link_to '編集する', edit_article_path(@article) %>
+                    <%= link_to '削除する', article_path(@article), data: { method: 'delete', confirm: '本当に削除してもよろしいですか？' } %>
                 </div>
             </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   root to: 'articles#index'
 
-  resources :articles, only: [:show, :new, :create, :edit, :update]
+  resources :articles, only: [:show, :new, :create, :edit, :update, :destroy]
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.16",
+    "@rails/ujs": "^7.1.3-4",
     "sass": "^1.89.2"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,6 +239,11 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-8.0.200.tgz#1d27d9d55e45266e061190db045925e0b4d53d6b"
   integrity sha512-EDqWyxck22BHmv1e+mD8Kl6GmtNkhEPdRfGFT7kvsv1yoXd9iYrqHDVAaR8bKmU/syC5eEZ2I5aWWxtB73ukMw==
 
+"@rails/ujs@^7.1.3-4":
+  version "7.1.3-4"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.3-4.tgz#1dddea99d5c042e8513973ea709b2cb7e840dc2d"
+  integrity sha512-z0ckI5jrAJfImcObjMT1RBz2IxH6I5q6ZTMFex6AfxSQKZuuL8JxAXvg2CvBuodGCxKvybFVolDyMHXlBLeYAA==
+
 braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"


### PR DESCRIPTION
### 削除ボタンの実装を追加
- 記事詳細ページに削除リンクを設置し、削除処理を行えるようにしました。
### 記事削除ボタンの動作不良を修正
- rails-ujs をimportし、JavaScriptのDELETEリクエストが正しく動作するよう対応しました。