### PR TITLE
HerokuへのDeploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'tzinfo-data', platforms: %i[ windows jruby ]
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem 'solid_cable'
 gem 'solid_cache'
-# gem 'solid_queue'
+gem 'solid_queue'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'tzinfo-data', platforms: %i[ windows jruby ]
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem 'solid_cable'
 gem 'solid_cache'
-gem 'solid_queue'
+# gem 'solid_queue'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,13 +151,8 @@ GEM
     erb (5.0.1)
     erubi (1.13.1)
     erubis (2.7.0)
-    et-orbi (1.2.11)
-      tzinfo
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
-    fugit (1.11.1)
-      et-orbi (~> 1, >= 1.2.11)
-      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     haml (6.3.0)
@@ -279,7 +274,6 @@ GEM
     public_suffix (6.0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
-    raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.16)
     rack-session (2.1.1)
@@ -364,7 +358,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     sexp_processor (4.17.3)
-    solid_cable (3.0.8)
+    solid_cable (3.0.11)
       actioncable (>= 7.2)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -373,13 +367,6 @@ GEM
       activejob (>= 7.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
-    solid_queue (1.1.5)
-      activejob (>= 7.1)
-      activerecord (>= 7.1)
-      concurrent-ruby (>= 1.3.1)
-      fugit (~> 1.11.0)
-      railties (>= 7.1)
-      thor (~> 1.3.1)
     sshkit (1.24.0)
       base64
       logger
@@ -465,7 +452,6 @@ DEPENDENCIES
   selenium-webdriver
   solid_cable
   solid_cache
-  solid_queue
   stimulus-rails
   thruster
   turbo-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,8 +151,13 @@ GEM
     erb (5.0.1)
     erubi (1.13.1)
     erubis (2.7.0)
+    et-orbi (1.2.11)
+      tzinfo
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     haml (6.3.0)
@@ -274,6 +279,7 @@ GEM
     public_suffix (6.0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.16)
     rack-session (2.1.1)
@@ -367,6 +373,13 @@ GEM
       activejob (>= 7.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
+    solid_queue (1.1.5)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11.0)
+      railties (>= 7.1)
+      thor (~> 1.3.1)
     sshkit (1.24.0)
       base64
       logger
@@ -452,6 +465,7 @@ DEPENDENCIES
   selenium-webdriver
   solid_cable
   solid_cache
+  solid_queue
   stimulus-rails
   thruster
   turbo-rails

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,6 @@
 web: bundle exec puma -C config/puma.rb
-release: bundle exec rake db:migrate
+release: |
+  bundle exec rails db:migrate
+  bundle exec rails db:migrate:cache
+  bundle exec rails db:migrate:queue
+  bundle exec rails db:migrate:cable

--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-release: |
-  bundle exec rails db:migrate
-  bundle exec rails db:migrate:cache
-  bundle exec rails db:migrate:queue
-  bundle exec rails db:migrate:cable
+release: bundle exec rails db:migrate && bundle exec rails db:migrate:cache && bundle exec rails db:migrate:queue && bundle exec rails db:migrate:cable

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,3 +19,8 @@ production:
   username: blogapp
   password: <%= ENV['DATABASE_PASSWORD'] %>
   host: <%= ENV['DATABASE_HOST'] %>
+
+  connects_to:
+    database:
+      writing: <%= ENV['DATABASE_URL'] %>
+      cache: <%= ENV['DATABASE_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  timeout: 5000
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
@@ -12,22 +13,14 @@ test:
   database: blogapp_test
 
 production:
-  primary: &primary_production
-    <<: *default
-    database: blogapp_production
-    username: blogapp
-    password: <%= ENV['DATABASE_PASSWORD'] %>
-    host: <%= ENV['DATABASE_HOST'] %>
+  primary:
+    url: <%= ENV['DATABASE_URL'] %>
   cache:
-    <<: *primary_production
-    database: blogapp_production_cache
+    url: <%= ENV['CACHE_DB_URL'] %>
     migrations_paths: db/cache_migrate
   queue:
-    <<: *primary_production
-    database: blogapp_production_queue
-    username: <%= ENV["DATABASE_USERNAME"] %>
+    url: <%= ENV['QUEUE_DB_URL'] %>
     migrations_paths: db/queue_migrate
   cable:
-    <<: *primary_production
-    database: blogapp_production_cable
+    url: <%= ENV['CABLE_DB_URL'] %>
     migrations_paths: db/cable_migrate

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,8 +1,6 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: 5
-  timeout: 5000
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
@@ -14,13 +12,22 @@ test:
   database: blogapp_test
 
 production:
-  <<: *default
-  database: blogapp_production
-  username: blogapp
-  password: <%= ENV['DATABASE_PASSWORD'] %>
-  host: <%= ENV['DATABASE_HOST'] %>
-
-  connects_to:
-    database:
-      writing: <%= ENV['DATABASE_URL'] %>
-      cache: <%= ENV['DATABASE_URL'] %>
+  primary: &primary_production
+    <<: *default
+    database: blogapp_production
+    username: blogapp
+    password: <%= ENV['DATABASE_PASSWORD'] %>
+    host: <%= ENV['DATABASE_HOST'] %>
+  cache:
+    <<: *primary_production
+    database: blogapp_production_cache
+    migrations_paths: db/cache_migrate
+  queue:
+    <<: *primary_production
+    database: blogapp_production_queue
+    username: <%= ENV["DATABASE_USERNAME"] %>
+    migrations_paths: db/queue_migrate
+  cable:
+    <<: *primary_production
+    database: blogapp_production_cable
+    migrations_paths: db/cable_migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :solid_cache_store
+  # config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :solid_queue

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Replace the default in-process memory cache store with a durable alternative.
-  # config.cache_store = :solid_cache_store
+  config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :solid_queue


### PR DESCRIPTION
## マルチDB（複数データベース）対応に関するエラー対応

### 1. config/database.ymlのマルチDB設定

本番環境でのマルチDB（cache / queue / cable）を以下のように定義：

```
production:
  primary:
    url: <%= ENV['DATABASE_URL'] %>
  cache:
    url: <%= ENV['CACHE_DB_URL'] %>
    migrations_paths: db/cache_migrate
  queue:
    url: <%= ENV['QUEUE_DB_URL'] %>
    migrations_paths: db/queue_migrate
  cable:
    url: <%= ENV['CABLE_DB_URL'] %>
    migrations_paths: db/cable_migrate
```
---

### 2. HerokuにマルチDB用のPostgreSQLアドオンを追加

```
heroku addons:create heroku-postgresql:essential-0 --as CACHE_DB --app aym-blog-app
heroku addons:create heroku-postgresql:essential-0 --as QUEUE_DB --app aym-blog-app
heroku addons:create heroku-postgresql:essential-0 --as CABLE_DB --app aym-blog-app
```
---

### 3. Herokuの環境変数（Config Vars）にURLが設定されたことを確認

以下のような環境変数が自動で設定されている：
- `CACHE_DB_URL`
- `QUEUE_DB_URL`
- `CABLE_DB_URL`
---

### 4. マルチDBのマイグレーションディレクトリの確認

以下のディレクトリ（migrations_paths で指定）が存在するかを確認：
- `db/migrate`
- `db/cache_migrate`
- `db/queue_migrate`
- `db/cable_migrate`

（空ディレクトリのため、`.keep`を置いてgit対応）

---

### 5. seeds.rb による db:prepare のバリデーションエラーの回避

db:prepare 実行時、既存レコードとの重複で ActiveRecord::RecordInvalid が発生したため、必要に応じて seeds.rb を調整。

---

### 6. Procfile の修正

構文エラーを修正し、マルチDBのマイグレーションを順に実行できるように以下のように定義：
```
web: bundle exec puma -C config/puma.rb
release: bundle exec rails db:migrate && bundle exec rails db:migrate:cache && bundle exec rails db:migrate:queue && bundle exec rails db:migrate:cable
```

---

### 7. Herokuログでの確認

`heroku logs --tail --app aym-blog-app` で、アプリが正常に起動していることを確認。

- `Puma starting...`
- `Welcome to AymBlogApp!`
- `State changed from starting to up`

が表示されていれば、デプロイ成功。

---

📌 最後に

今後の検討事項：
- 必要なマルチDB数の精査（コスト管理）
- DB統合の設計見直し