### PR TITLE
feat: implement follow/unfollow feature and user account's page

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -15,7 +15,7 @@ $back-icon-size: 16px;
     color: white;
   }
 
-  &_loginBtn {
+  a.header_loginBtn {
     background-color: variables.$base-bg-color;
     height: $avatar-size;
     border-radius: 8px;

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,5 @@
+class AccountsController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+  end
+end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,5 +1,9 @@
 class AccountsController < ApplicationController
   def show
     @user = User.find(params[:id])
+    # user が自分の場合、account ではなく profile を表示
+    if @user == current_user
+      redirect_to profile_path
+    end
   end
 end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,0 +1,8 @@
+class FollowsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    current_user.follow!(params[:account_id])
+    redirect_to account_path(params[:account_id])
+  end
+end

--- a/app/controllers/unfollows_controller.rb
+++ b/app/controllers/unfollows_controller.rb
@@ -1,0 +1,8 @@
+class UnfollowsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    current_user.unfollow!(params[:account_id])
+    redirect_to account_path(params[:account_id])
+  end
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -15,4 +15,6 @@
 #
 
 class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: 'User'
+  belongs_to :following, class_name: 'User'
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id           :integer          not null, primary key
+#  following_id :integer          not null
+#  follower_id  :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_relationships_on_follower_id   (follower_id)
+#  index_relationships_on_following_id  (following_id)
+#
+
+class Relationship < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ApplicationRecord
   has_many :following_relationships, foreign_key: 'follower_id', class_name: 'Relationship', dependent: :destroy
   has_many :followings, through: :following_relationships, source: :following
 
+  has_many :follower_relationships, foreign_key: 'following_id', class_name: 'Relationship', dependent: :destroy
+  has_many :followers, through: :follower_relationships, source: :follower
+
   has_one :profile, dependent: :destroy
 
   delegate :birthday, :age, :gender, to: :profile, allow_nil: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,10 @@ class User < ApplicationRecord
   has_many :articles, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :favorites_articles, through: :likes, source: :article
+
+  has_many :following_relationships, foreign_key: 'follower_id', class_name: 'Relationship', dependent: :destroy
+  has_many :followings, through: :following_relationships, source: :following
+
   has_one :profile, dependent: :destroy
 
   delegate :birthday, :age, :gender, to: :profile, allow_nil: true
@@ -21,6 +25,10 @@ class User < ApplicationRecord
 
   def display_name
     profile&.nickname || self.email.split('@').first
+  end
+
+  def follow!(user)
+    following_relationships.create!(following_id: user.id) # follower_id は current_user が自動的に指定される
   end
 
   def prepare_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,12 +31,24 @@ class User < ApplicationRecord
   end
 
   def follow!(user)
-    following_relationships.create!(following_id: user.id) # follower_id は current_user が自動的に指定される
+    # User オブジェクトが渡された場合も、user_id が渡された場合も対応できる
+    if user.is_a?(User)
+      user_id = user.id
+    else
+      user_id = user
+    end
+
+    following_relationships.create!(following_id: user_id)
+    # follower_id は current_user が自動的に指定される
   end
 
   def unfollow!(user)
     relation = following_relationships.find_by!(following_id: user.id)
     relation.destroy!
+  end
+
+  def has_followed?(user)
+    following_relationships.exists?(following_id: user.id)
   end
 
   def prepare_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,11 @@ class User < ApplicationRecord
     following_relationships.create!(following_id: user.id) # follower_id は current_user が自動的に指定される
   end
 
+  def unfollow!(user)
+    relation = following_relationships.find_by!(following_id: user.id)
+    relation.destroy!
+  end
+
   def prepare_profile
     profile || build_profile
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,19 +31,15 @@ class User < ApplicationRecord
   end
 
   def follow!(user)
-    # User オブジェクトが渡された場合も、user_id が渡された場合も対応できる
-    if user.is_a?(User)
-      user_id = user.id
-    else
-      user_id = user
-    end
+    user_id = get_user_id(user)
 
     following_relationships.create!(following_id: user_id)
     # follower_id は current_user が自動的に指定される
   end
 
   def unfollow!(user)
-    relation = following_relationships.find_by!(following_id: user.id)
+    user_id = get_user_id(user)
+    relation = following_relationships.find_by!(following_id: user_id)
     relation.destroy!
   end
 
@@ -62,4 +58,14 @@ class User < ApplicationRecord
       'default-avatar.png'
     end
   end
+
+  private
+  def get_user_id(user)
+    if user.is_a?(User)
+      user.id
+    else
+      user
+    end
+  end
+
 end

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -1,1 +1,1 @@
-= @user.email
+= render 'commons/profile', user: @user

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -1,0 +1,1 @@
+= @user.email

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -4,7 +4,8 @@
       = image_tag @article.eyecatch
   %h1.article_title= @article.title
   .article_detail
-    = image_tag @article.user.avatar_image
+    = link_to account_path(@article.user) do
+      = image_tag @article.user.avatar_image
     %div
       %p= @article.author_name
       %p= @article.display_created_at

--- a/app/views/commons/_profile.html.haml
+++ b/app/views/commons/_profile.html.haml
@@ -11,7 +11,7 @@
             = link_to 'Edit', edit_profile_path
           - else
             - if current_user&.has_followed?(user) # current_user が Nil の場合は実行しない
-              %p フォロー済み
+              = link_to 'Unfollow', account_unfollows_path(user), data: { turbo_method: 'post' }
             - else
               = link_to 'Follow', account_follows_path(user), data: { turbo_method: 'post' }
       .profilePage_user_introduction

--- a/app/views/commons/_profile.html.haml
+++ b/app/views/commons/_profile.html.haml
@@ -1,0 +1,18 @@
+.container.profilePage
+  .profilePage_user
+    .profilePage_user_image
+      = image_tag user.avatar_image
+    .profilePage_user_basicInfo
+      .profilePage_user_name
+        .profilePage_user_displayName
+          #{user.display_name} （#{user.age || '？歳'}・#{I18n.t("enum.genders.#{user.gender || 'unknown'}")}）
+        .profilePage_user_actionButton
+          - if user == current_user
+            = link_to 'Edit', edit_profile_path
+          - else
+            = link_to 'Follow', '#'
+      .profilePage_user_introduction
+        = user.profile&.introduction
+
+  - user.articles.each do |article|
+    = render 'commons/article', article: article

--- a/app/views/commons/_profile.html.haml
+++ b/app/views/commons/_profile.html.haml
@@ -10,7 +10,10 @@
           - if user == current_user
             = link_to 'Edit', edit_profile_path
           - else
-            = link_to 'Follow', '#'
+            - if current_user&.has_followed?(user) # current_user が Nil の場合は実行しない
+              %p フォロー済み
+            - else
+              = link_to 'Follow', account_follows_path(user), data: { turbo_method: 'post' }
       .profilePage_user_introduction
         = user.profile&.introduction
 

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,15 +1,1 @@
-.container.profilePage
-  .profilePage_user
-    .profilePage_user_image
-      = image_tag current_user.avatar_image
-    .profilePage_user_basicInfo
-      .profilePage_user_name
-        .profilePage_user_displayName
-          #{current_user.display_name} （#{current_user.age}・#{I18n.t("enum.genders.#{current_user.gender}")}）
-        .profilePage_user_actionButton
-          = link_to 'Edit', edit_profile_path
-      .profilePage_user_introduction
-        = current_user.profile&.introduction
-
-  - current_user.articles.each do |article|
-    = render 'commons/article', article: article
+= render 'commons/profile', user: current_user

--- a/config/locales/enum.ja.yml
+++ b/config/locales/enum.ja.yml
@@ -4,3 +4,4 @@ ja:
       male: '男性'
       female: '女性'
       other: 'その他'
+      unknown: '性別未入力'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
     resource :like, only: [:create, :destroy]
   end
 
-  resources :accounts, only: [:show]
+  resources :accounts, only: [:show] do
+    resources :follows, only: [:create]
+  end
 
   resource :profile, only: [:show, :edit, :update]
    # userに対してindexは1つなのでindexは不要

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     resource :like, only: [:create, :destroy]
   end
 
+  resources :accounts, only: [:show]
+
   resource :profile, only: [:show, :edit, :update]
    # userに対してindexは1つなのでindexは不要
   resources :favorites, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
 
   resources :accounts, only: [:show] do
     resources :follows, only: [:create]
+    resources :unfollows, only: [:create]
   end
 
   resource :profile, only: [:show, :edit, :update]

--- a/db/migrate/20250701135037_create_relationships.rb
+++ b/db/migrate/20250701135037_create_relationships.rb
@@ -1,0 +1,9 @@
+class CreateRelationships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :relationships do |t|
+      t.references :following, null: false, foreign_key: { to_table: :users }
+      t.references :follower, null: false, foreign_key: { to_table: :users }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_01_070655) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_01_135037) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -89,6 +89,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_070655) do
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
+  create_table "relationships", force: :cascade do |t|
+    t.bigint "following_id", null: false
+    t.bigint "follower_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
+    t.index ["following_id"], name: "index_relationships_on_following_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -103,4 +112,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_070655) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "relationships", "users", column: "follower_id"
+  add_foreign_key "relationships", "users", column: "following_id"
 end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id           :integer          not null, primary key
+#  following_id :integer          not null
+#  follower_id  :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_relationships_on_follower_id   (follower_id)
+#  index_relationships_on_following_id  (following_id)
+#
+
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id           :integer          not null, primary key
+#  following_id :integer          not null
+#  follower_id  :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_relationships_on_follower_id   (follower_id)
+#  index_relationships_on_following_id  (following_id)
+#
+
+require "test_helper"
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要

* フォロー・アンフォロー機能の実装
* ユーザーアカウントページの表示・改善
* 共通パーツ _profile.html.haml の作成

## やったこと

* Relationshipsテーブルの作成
* follow/unfollow処理をモデル・コントローラーで実装
* ユーザーアカウントページの作成
* common/_profile.html.haml テンプレートを新規作成し、共通化
* follow/unfollowボタンの切り替え表示
* CSS調整

## 変更内容

### UIの変更

- accountページ
   <img width="591" alt="image" src="https://github.com/user-attachments/assets/10fc84b1-1247-4dd1-ac8a-e731cceb9791" />
- _profile.html.haml を使った共通レイアウト化
- follow/unfollowボタンの状態切り替え

### APIの変更
- GET /accounts/:id
- POST /accounts/:id/follows
- POST /accounts/:id/unfollows

## 影響範囲

- ユーザー： フォロー・アンフォローが可能に
- システム： Relationshipモデルとアソシエーションの追加

## 動作確認
https://github.com/user-attachments/assets/b07cbcb3-4c83-4298-91ef-6ec28c52571f
* accountページで他ユーザーのfollow/unfollowを確認
* current_userのaccountページはprofileページにリダイレクトされることを確認
* _profile.html.haml のレンダリングに問題がないことを確認
* Railsコンソールで User.first.followings などの関連取得も確認済み
   <img width="591" alt="image" src="https://github.com/user-attachments/assets/9423ed26-841f-40e9-aade-d452e1e65535" />