### PR TITLE
feat: 通知メール送信機能の追加と本番用SMTP設定の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,8 @@ group :development do
   gem 'haml-rails'
   gem 'html2haml'
   gem 'web-console'
+  gem 'letter_opener'
+  gem 'letter_opener_web'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,8 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
+    childprocess (5.1.0)
+      logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -225,6 +227,17 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -486,6 +499,8 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kamal
+  letter_opener
+  letter_opener_web
   mini_magick
   pg (>= 0.18, < 2.0)
   propshaft

--- a/app/mailers/relationship_mailer.rb
+++ b/app/mailers/relationship_mailer.rb
@@ -1,0 +1,9 @@
+class RelationshipMailer < ApplicationMailer
+
+  def new_follower(user, follower)
+    @user = user
+    @follower = follower
+    mail to: user.email, subject: '【お知らせ】フォローされました！'
+  end
+
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -17,4 +17,11 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: 'User'
   belongs_to :following, class_name: 'User'
+
+  after_create :send_email
+
+  private
+  def send_email
+    RelationshipMailer.new_follower(following, follower).deliver_now
+  end
 end

--- a/app/views/relationship_mailer/new_follower.html.haml
+++ b/app/views/relationship_mailer/new_follower.html.haml
@@ -1,0 +1,4 @@
+%p #{@user.email} さん
+%p 以下のユーザにフォローされました。
+
+= link_to 'プロフィールを確認する', account_url(@follower)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,9 @@ Rails.application.configure do
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,6 +69,20 @@ Rails.application.configure do
   #   authentication: :plain
   # }
 
+  # 送信者のメールアドレスのドメイン（仮）
+  config.action_mailer.default_url_options = { host: 'example.com' }
+
+  # Mailgun
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    port:           ENV['MAILGUN_SMTP_PORT'],
+    address:        ENV['MAILGUN_SMTP_SERVER'],
+    user_name:      ENV['MAILGUN_SMTP_LOGIN'],
+    password:       ENV['MAILGUN_SMTP_PASSWORD'],
+    domain:         ENV['HEROKU_DOMAIN'],
+    authentication: :plain,
+  }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,18 +60,6 @@ Rails.application.configure do
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: 'example.com' }
 
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
-
-  # 送信者のメールアドレスのドメイン（仮）
-  config.action_mailer.default_url_options = { host: 'example.com' }
-
   # Mailgun
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
## 変更の概要
- フォロー時に通知メールを送信する機能を追加しました。
- ローカル開発環境用に letter_opener を導入し、メールのデバッグを可能にしました。
- 本番環境用に Mailgun の SMTP 設定を追加しました。


## やったこと
- RelationshipMailer クラスと new_follower メールテンプレートを作成
- Relationship モデルに after_create コールバックで通知メールを送信する処理を追加
- ローカル用に letter_opener を導入し、development環境に設定
- 本番用に Mailgun SMTP を使う ActionMailer 設定を追加

## 変更内容

📮 送信されるメール内容（例）
```
件名: 【お知らせ】フォローされました！
本文:
  [ユーザー名] さん
以下のユーザにフォローされました。

[プロフィールを確認する](フォロワーのプロフィールページ)
```

## 影響範囲
- ユーザー: フォローされた際にメール通知を受け取るようになる
- 開発者: メール送信に関する環境構築・テストが必要
- システム: 外部メールサービス（Mailgun）との通信が発生

## 動作確認

https://github.com/user-attachments/assets/68eb9f35-1477-4c57-82e4-4dd5345c1829

- ローカル環境で letter_opener 経由でのメール表示を確認
- rails c で Relationship を作成し、メールが送信されることを確認