### PR TITLE
Feature/setup mailgun smtp

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'ciany.f@gmail.com'
   layout 'mailer'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: 'example.com' }
+  config.action_mailer.default_url_options = { host: 'aym-blog-app-32f1f970315f.herokuapp.com' }
 
   # Mailgun
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,21 +55,24 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: 'aym-blog-app-32f1f970315f.herokuapp.com' }
 
   # Mailgun
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
+  ActionMailer::Base.delivery_method = :smtp
+  ActionMailer::Base.smtp_settings = {
     port:           ENV['MAILGUN_SMTP_PORT'],
     address:        ENV['MAILGUN_SMTP_SERVER'],
     user_name:      ENV['MAILGUN_SMTP_LOGIN'],
     password:       ENV['MAILGUN_SMTP_PASSWORD'],
-    domain:         ENV['HEROKU_DOMAIN'],
+    domain:         ENV['MAILGUN_DOMAIN'],
     authentication: :plain,
   }
+
+  config.action_mailer.logger = Logger.new(STDOUT)
+  config.action_mailer.logger.level = Logger::DEBUG
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
本番環境（Heroku）でメール送信ができるように、以下の設定を修正しました。

### 変更内容
- `config/environments/production.rb`：
  - SMTP設定を明示的に記述（環境変数経由）
  - `config.action_mailer.default_url_options` に Heroku のホスト名を設定
- `app/mailers/application_mailer.rb`：
  - `default from:` に有効な送信元メールアドレスを指定

### 確認事項
- フォロー時の通知メールが正常に送信され、Gmailで受信できることを確認
   <img width="623" alt="image" src="https://github.com/user-attachments/assets/89ed821c-a3d0-41d4-b74a-f34aa6c4e8af" />
- 本番環境にデプロイ後、フォーム操作にて500エラーが発生しないことを確認

### 💬 備考
Herokuの以下の環境変数は手動で上書きしました。
- MAILGUN_DOMAIN
- MAILGUN_SMTP_LOGIN
- MAILGUN_SMTP_PASSWORD