### PR TITLE
Add Request Specs for Articles and API Comments

### DIFF
--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :comment do
+    content { Faker::Lorem.characters(number: 300) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,4 +71,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Comments', type: :request do
+  let!(:user) { create(:user) }
+  let!(:article) { create(:article, user: user) }
+  let!(:comments) { create_list(:comment, 3, article: article) }
+
+  describe 'GET /api/comments' do
+    it '200 Status' do
+      get api_comments_path(article_id: article.id)
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe 'Api::Comments', type: :request do
     it '200 Status' do
       get api_comments_path(article_id: article.id)
       expect(response).to have_http_status(200)
+
+      body = JSON.parse(response.body)
+      expect(body.length).to eq 3
+      expect(body[0]['content']).to eq comments.first.content
+      expect(body[1]['content']).to eq comments.second.content
+      expect(body[2]['content']).to eq comments.third.content
     end
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -10,4 +10,29 @@ RSpec.describe 'Articles', type: :request do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe 'POST /articles' do
+    context 'ログインしている場合' do
+      before do
+        sign_in user
+      end
+
+      it '記事が保存される' do
+        # POST => リクエストパラメータを作る
+        article_params = attributes_for(:article)
+        post articles_path({article: article_params})
+        expect(response).to have_http_status(302)
+        expect(Article.last.title).to eq(article_params[:title])
+        expect(Article.last.content.body.to_plain_text).to eq(article_params[:content])
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it 'ログイン画面に遷移する' do
+        article_params = attributes_for(:article)
+        post articles_path({article: article_params})
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'Articles', type: :request do
+  let!(:user) { create(:user) }
+  let!(:articles) { create_list(:article, 10, user: user) }
+
+  describe 'GET /articles' do
+    it '200ステータスが返ってくる' do
+      get articles_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

本PRでは、以下のRequest Specに関する実装・設定を行いました：
- Articleの作成に関するリクエストスペックを追加（認証あり・なしのケース両方を検証）
- API用のコメント一覧取得（GET）に関するリクエストスペックを作成
- レスポンスボディの内容検証を追加
- リクエストスペックでDeviseの認証サポートを有効化

## 追加・変更内容
- spec/requests/articles_spec.rb を作成
- spec/requests/api/comments_spec.rb を作成
- spec/factories/comments.rb を追加（FactoryBot）
- rails_helper.rb に Devise のリクエストスペック用モジュールを設定
- APIコメント一覧のレスポンスボディに含まれるデータを検証するテストを追加

## 動作確認
- bundle exec rspec にて全テスト通過済み
- 認証の有無に応じた挙動が期待通りに動作していることを確認
<img width="577" height="339" alt="image" src="https://github.com/user-attachments/assets/b3452feb-e563-4d19-81ad-489a8f123f96" />
